### PR TITLE
Add custom error pages

### DIFF
--- a/src/Resources/views/Admin/Import/Liste/detail.html.twig
+++ b/src/Resources/views/Admin/Import/Liste/detail.html.twig
@@ -1,5 +1,5 @@
 
-{% extends " layout.html.twig" %}
+{% extends "layout.html.twig" %}
 
 {% from "PHPKTemplateBundle::import.html.twig" import phpk %}
 

--- a/src/Resources/views/Admin/Import/Liste/liste.html.twig
+++ b/src/Resources/views/Admin/Import/Liste/liste.html.twig
@@ -1,4 +1,4 @@
-{% extends " layout.html.twig" %}
+{% extends "layout.html.twig" %}
 
 
 {% from "PHPKTemplateBundle::import.html.twig" import phpk %}

--- a/src/Resources/views/Admin/Import/fichier.html.twig
+++ b/src/Resources/views/Admin/Import/fichier.html.twig
@@ -1,4 +1,4 @@
-{% extends " layout.html.twig" %}
+{% extends "layout.html.twig" %}
 
 {% from "PHPKTemplateBundle::import.html.twig" import phpk %}
 

--- a/src/Resources/views/Admin/Parametrage/parametrage.html.twig
+++ b/src/Resources/views/Admin/Parametrage/parametrage.html.twig
@@ -1,4 +1,4 @@
-{% extends " layout.html.twig" %}
+{% extends "layout.html.twig" %}
 
 {% from "PHPKTemplateBundle::import.html.twig" import phpk %}
 

--- a/src/Resources/views/Default/index.html.twig
+++ b/src/Resources/views/Default/index.html.twig
@@ -1,4 +1,4 @@
-{% extends " layout.html.twig" %}
+{% extends "layout.html.twig" %}
 {% from "PHPKTemplateBundle::import.html.twig" import phpk %}
 {% block body %}
 

--- a/src/Resources/views/Requete/globale.html.twig
+++ b/src/Resources/views/Requete/globale.html.twig
@@ -1,4 +1,4 @@
-{% extends " layout.html.twig" %}
+{% extends "layout.html.twig" %}
 {% from "PHPKTemplateBundle::import.html.twig" import phpk %}
 
 {% block body %}

--- a/src/Resources/views/Requete/praticien.html.twig
+++ b/src/Resources/views/Requete/praticien.html.twig
@@ -1,4 +1,4 @@
-{% extends " layout.html.twig" %}
+{% extends "layout.html.twig" %}
 
 {% block body %}
     Bienvenue sur votre projet PHPK ! requete praticien

--- a/src/Resources/views/Requete/resultat.html.twig
+++ b/src/Resources/views/Requete/resultat.html.twig
@@ -1,4 +1,4 @@
-{% extends " layout.html.twig" %}
+{% extends "layout.html.twig" %}
 {% from "PHPKTemplateBundle::import.html.twig" import phpk %}
 {% block body %}
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <title>{% block title %}Welcome!{% endblock %}</title>
+        {% block stylesheets %}{% endblock %}
+        <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}" />
+    </head>
+    <body>
+        {% block body %}{% endblock %}
+        {% block javascripts %}{% endblock %}
+    </body>
+</html>

--- a/templates/bundles/TwigBundle/Exception/error400.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error400.html.twig
@@ -1,0 +1,21 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+
+    <div>
+
+        <div class="chzn-container">
+
+
+            <h1>
+                Requête incorrecte, contacter le service support informatique
+            </h1>
+            <h2>
+                {{ status_code }}- {{ status_text }}
+
+            </h2>
+
+        </div>
+
+    </div>
+
+{% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error401.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error401.html.twig
@@ -1,0 +1,21 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+
+    <div>
+
+        <div class="chzn-container">
+
+
+            <h1>
+                Vous n'êtes pas autorisé à accéder à cette application
+            </h1>
+            <h2>
+                {{ status_code }}- {{ status_text }}
+
+            </h2>
+
+        </div>
+
+    </div>
+
+{% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -1,0 +1,9 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+    <div>
+        <div class="chzn-container">
+            <h1>Accès interdit, vous n'êtes pas autorisé à accéder à cette ressource</h1>
+            <h2>{{ status_code }}- {{ status_text }}</h2>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -1,0 +1,22 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+
+    <div>
+
+        <div class="chzn-container">
+
+
+            <h1>
+                Ho! Page non trouvée, cliquez pour retourner à l'accueil
+                <a href="{{ path('app_index') }}">Retour Accueil</a>
+            </h1>
+            <h2>
+                {{ status_code }}- {{ status_text }}
+
+            </h2>
+
+        </div>
+
+    </div>
+
+{% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error408.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error408.html.twig
@@ -1,0 +1,22 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+
+    <div>
+
+        <div class="chzn-container">
+
+
+            <h1>
+                Délai d'attente dépassé
+                <a href="{{ path('app_index') }}">Retour Accueil</a>
+            </h1>
+            <h2>
+                {{ status_code }}- {{ status_text }}
+
+            </h2>
+
+        </div>
+
+    </div>
+
+{% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error500.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error500.html.twig
@@ -1,0 +1,25 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+
+    <div>
+
+        <div class="chzn-container">
+
+
+            <h1>
+                Erreur Serveur interne: Rafraichir la page
+                ou
+                <a href="{{ path('app_index') }}">Retour Accueil</a>
+
+            </h1>
+            <h2>
+                {{ status_code }}- {{ status_text }}
+
+            </h2>
+
+
+        </div>
+
+    </div>
+
+{% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error503.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error503.html.twig
@@ -1,0 +1,22 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+
+    <div>
+
+        <div class="chzn-container">
+
+
+            <h1>
+                Service non disponible, le serveur est temporairement indisponible
+
+            </h1>
+            <h2>
+                {{ status_code }}- {{ status_text }}
+
+            </h2>
+
+        </div>
+
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- fix extends paths for layout templates
- expose custom error templates under templates/
- add new 403 error page

## Testing
- `git status --short`
