### PR TITLE
Refactor RequeteGlobale form handling

### DIFF
--- a/src/Controller/RequeteController/RequeteGlobaleController.php
+++ b/src/Controller/RequeteController/RequeteGlobaleController.php
@@ -97,56 +97,50 @@ class RequeteGlobaleController extends AbstractController
                 //recupère la période
                 $periode = $periodeEnCours[0]->getCode();
 
-                if (isset($_POST['appbundle_requeteglobale']['theme']) && count($_POST['appbundle_requeteglobale']['theme']) >= 2) {
+                $submittedData = $request->request->get('appbundle_requeteglobale', []);
 
-                    if (isset($_POST['appbundle_requeteglobale']['praticien']['utaa']['code_utaa'])
-                        && $_POST['appbundle_requeteglobale']['praticien']['utaa']['code_utaa'] !== '') {
+                if (isset($submittedData['theme']) && count($submittedData['theme']) >= 2) {
 
-                        $utaaId = $_POST['appbundle_requeteglobale']['praticien']['utaa']['code_utaa'];
-
+                    if (!empty($submittedData['praticien']['utaa']['code_utaa'])) {
+                        $utaaId = $submittedData['praticien']['utaa']['code_utaa'];
                     } else {
-
                         $utaaId = '0';
-
                     }
 
                     //récupere l'ageId
-                    if (isset($_POST['appbundle_requeteglobale']['age'])) {
-
-                        $ageId = $_POST['appbundle_requeteglobale']['age']['code_age'];
-
+                    if (isset($submittedData['age'])) {
+                        $ageId = $submittedData['age']['code_age'];
                     } else {
-
                         $ageId = '';
                     }
 
-                    if ($ageId === '') $ageId = '0';
+                    if ($ageId === '') {
+                        $ageId = '0';
+                    }
 
                     //recupère l id de la période
                     $periodeId = $periodeEnCours[0]->getId();
 
                     //recupère id de theme
-                    $themeId = $_POST['appbundle_requeteglobale']['theme']['theme'];
+                    $themeId = $submittedData['theme']['theme'];
 
                     //recupère le tableau de commentaires et mise en session
                     $commentaire = array_diff_key(
-                        $_POST['appbundle_requeteglobale']['theme'],
-                        ['theme' => 0]);
+                        $submittedData['theme'],
+                        ['theme' => 0]
+                    );
 
                     $session->set('commentaire', $commentaire);
 
                     //récupère l'id du departement
-                    if ($_POST['appbundle_requeteglobale']['praticien']['utaa']['departement']) {
-
-                        $depId = $_POST['appbundle_requeteglobale']['praticien']['utaa']['departement'];
-
+                    if (!empty($submittedData['praticien']['utaa']['departement'])) {
+                        $depId = $submittedData['praticien']['utaa']['departement'];
                     } else {
-
                         $depId = '';
-
-
                     }
-                    if ($depId === '') $depId = '0';
+                    if ($depId === '') {
+                        $depId = '0';
+                    }
 
                     return $this->redirectToRoute('app_requete_globale_resultat'
 

--- a/src/Form/ageType.php
+++ b/src/Form/ageType.php
@@ -14,6 +14,7 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class ageType
@@ -29,7 +30,17 @@ class ageType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
 
-        $idTheme = $_POST['appbundle_requeteglobale']['theme']['theme'];
+        // Retrieve the theme id either from options or from the request data
+        $idTheme = $options['theme_id'] ?? null;
+
+        // The field can be added dynamically without the option, in that case
+        // try to read it from the submitted request (when available)
+        if (null === $idTheme && isset($options['request'])) {
+            $formData = $options['request']->request->get('appbundle_requeteglobale', []);
+            if (isset($formData['theme']['theme'])) {
+                $idTheme = $formData['theme']['theme'];
+            }
+        }
 
         $builder
             ->add('code_age', EntityType::class, [
@@ -63,9 +74,9 @@ class ageType extends AbstractType
     {
         $resolver->setDefaults(
             [
-
                 'data_class' => Age::class,
-
+                'theme_id' => null,
+                'request' => null,
             ]
         );
     }

--- a/src/Form/dataType.php
+++ b/src/Form/dataType.php
@@ -102,13 +102,14 @@ class dataType extends AbstractType
                 if ($event->getForm()->isSubmitted()) {
 
                     //si l'ageId est null, on affiche le composant de formulaire 'age
-                    if ($this->entityManager->getRepository(Data::class)
+                    $theme = $form->getData();
+
+                    if ($theme !== null && $this->entityManager->getRepository(Data::class)
                             ->SelectAgeIdFromData(
-                                $form->get('theme')
-                                    ->getData()
+                                $theme
                                     ->getId())[0] !== ['age_id' => null]) {
 
-                        $this->addAgeField($form->getParent());
+                        $this->addAgeField($form->getParent(), $theme->getId());
                     }
 
                 }
@@ -118,11 +119,12 @@ class dataType extends AbstractType
 
 
     /**
-     *
+     * Add the age field filtered by the provided theme
      *
      * @param FormInterface $form
+     * @param int $themeId
      */
-    private function addAgeField(FormInterface $form)
+    private function addAgeField(FormInterface $form, int $themeId)
     {
 
         $form->add(
@@ -130,7 +132,8 @@ class dataType extends AbstractType
             ageType::class,
             [
                 'label_attr' => ['id' => 'label_age'],
-                'attr' => ['class' => 'class_age']
+                'attr' => ['class' => 'class_age'],
+                'theme_id' => $themeId
             ]
 
         );


### PR DESCRIPTION
## Summary
- pass theme ID to `ageType` via option
- avoid direct `$_POST` usage in `RequeteGlobaleController`
- update `dataType` to forward selected theme ID

## Testing
- `phpunit` *(fails: command not found)*