### PR TITLE
Fix praticien linkage when adding to Utaa

### DIFF
--- a/src/Entity/Utaa.php
+++ b/src/Entity/Utaa.php
@@ -138,13 +138,11 @@ class Utaa
         foreach ($praticiens as $praticien) {
             if (!$this->praticiens->contains($praticien)) {
                 $this->praticiens->add($praticien);
-                $this->setUtaa($this);
-
+                $praticien->setUtaa($this);
             }
-
         }
-        return $this;
 
+        return $this;
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure each praticien added to a Utaa references its Utaa
- remove incorrect self-call

## Testing
- `php -l src/Entity/Utaa.php` *(fails: `php` not found)*