### PR TITLE
Fix console bootstrap

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,25 +3,24 @@
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
+use App\Kernel;
 
 // if you don't want to setup permissions the proper way, just uncomment the following PHP line
 // read https://symfony.com/doc/current/setup.html#checking-symfony-application-configuration-and-setup
 // for more information
 //umask(0000);
 
-set_time_limit(5000);
-
 require __DIR__.'/../vendor/autoload.php';
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev', true);
-$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption('--no-debug', true) && $env !== 'prod';
+$env = $input->getParameterOption(['--env', '-e'], getenv('APP_ENV') ?: 'dev', true);
+$debug = getenv('APP_DEBUG') !== '0' && !$input->hasParameterOption('--no-debug', true) && $env !== 'prod';
 
 if ($debug) {
     Debug::enable();
 }
 
-$kernel = new AppKernel($env, $debug);
+$kernel = new Kernel($env, $debug);
 $application = new Application($kernel);
 $application->run($input);


### PR DESCRIPTION
## Summary
- update console to use `App\Kernel`
- remove old bootstrap code and rely on `APP_*` env vars

## Testing
- `php -l bin/console` *(fails: `php: command not found`)*