### PR TITLE
Fix built-in server command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This project has been updated to use Symfony 7.3.
 composer install
 ```
 
-Run the application using the built-in PHP server:
+Run the application using the built-in PHP server and the project front controller:
 
 ```bash
-php -S localhost:8000 -t public
+php -S localhost:8000 -t web web/app.php
 ```
 
 Ensure you have PHP 8.1 or higher.


### PR DESCRIPTION
## Summary
- correct the built-in server command to reference `web/app.php`

## Testing
- `composer validate --no-check-lock` *(fails: composer not installed)*